### PR TITLE
Load Text::Abbrev only on demand

### DIFF
--- a/lib/App/Cmd.pm
+++ b/lib/App/Cmd.pm
@@ -9,7 +9,6 @@ BEGIN { our @ISA = 'App::Cmd::ArgProcessor' };
 
 use File::Basename ();
 use Module::Pluggable::Object ();
-use Text::Abbrev ();
 use Class::Load ();
 
 use Sub::Exporter -setup => {
@@ -181,6 +180,7 @@ sub _command {
 
   if ($self->allow_any_unambiguous_abbrev) {
     # add abbreviations to list of authorized commands
+    require Text::Abbrev;
     my %abbrev = Text::Abbrev::abbrev( keys %plugin );
     @plugin{ keys %abbrev } = @plugin{ values %abbrev };
   }


### PR DESCRIPTION
Text::Abbrev is only used for the allow_any_unambiguous_abbrev option. This patch loads the module only when the option is used.

Side-effect: as the allow_any_unambiguous_abbrev option is not used in Dist::Zilla, this should improve DZ startup a bit (one less module loaded).
