### PR TITLE
Resolves capture-ext.t fails on MSWin32

### DIFF
--- a/t/lib/Test/MyCmd/Command/hello.pm
+++ b/t/lib/Test/MyCmd/Command/hello.pm
@@ -10,9 +10,14 @@ use IPC::Cmd qw/can_run/;
 sub execute {
   my ($self, $opt, $arg) =@_;
 
-  my $echo = can_run("echo");
-  $self->usage_error("Program 'echo' not found") unless $echo;
-  system($echo, "Hello World");
+  if ( $^O eq 'MSWin32' ) {
+    system('cmd', '/c', 'echo', "Hello World");
+  }
+  else {
+    my $echo = can_run("echo");
+    $self->usage_error("Program 'echo' not found") unless $echo;
+    system($echo, "Hello World");
+  }
   return;
 }
 


### PR DESCRIPTION
ECHO is a CMD.exe built-in on MSWin32, so use CMD.exe explicitly when on Windows.
