### PR TITLE
Working implementation of basic 'Elective' design

### DIFF
--- a/lib/App/Cmd/Base/Elective.pm
+++ b/lib/App/Cmd/Base/Elective.pm
@@ -1,0 +1,72 @@
+use strict;
+use warnings;
+
+package App::Cmd::Base::Elective;
+
+# ABSTRACT: A Base class for App::Cmd that uses a whitelist instead of Module::Pluggable
+
+use parent 'App::Cmd';
+
+use Module::Runtime qw( compose_module_name module_notional_filename );
+use Class::Load qw( load_optional_class );
+
+=head1 SYNOPSIS
+
+Preferred: 
+
+    package Foo;
+    use App::Cmd::Elective -app;
+    sub app_commands { }
+
+Which is similar, but not identical to
+
+    package Foo;
+    use App::Cmd::Base::Elective;
+    use parent "App::Cmd::Base::Elective";
+
+See L<App::Cmd::Tutorial> for more in depth usage. 
+
+=cut
+
+sub _expand_plugin_possible_names {
+  my ( $self, $plugin_name ) = @_;
+  return map { compose_module_name( $_, $plugin_name ) } @{ $self->plugin_search_path };
+}
+
+sub _expand_plugin_name {
+  my ( $self, $plugin_name ) = @_;
+  my (@candidates) = $self->_expand_plugin_possible_names($plugin_name);
+  for my $candidate (@candidates) {
+    return $candidate if load_optional_class($candidate);
+  }
+  my $message = 'Sorry, no plugin named <<' . $plugin_name . qq[>> could be found\n];
+  $message .= qq[We tried the following expansions:\n];
+  $message .= qq[\t$_\n] for @candidates;
+  $message .= qq[\@INC contains:\n];
+  $message .= qq[\t$_\n] for @INC;
+  require Carp;
+  Carp::croak($message);
+}
+
+my %plugins_for;
+
+sub _plugins {
+  my ($self) = @_;
+  my $class = ref $self || $self;
+
+  return @{ $plugins_for{$class} } if $plugins_for{$class};
+
+  if ( not $class->can('app_commands') ) {
+    require Carp;
+    Carp::croak( 'Class <<' . $class . '>> lacks required method << app_commands >>' );
+  }
+
+  my @plugins;
+  my (@search_path) = @{ $self->plugin_search_path };
+  for my $plugin ( $self->app_commands ) {
+    push @plugins, $self->_expand_plugin_name($plugin);
+  }
+  return @plugins;
+}
+
+1;

--- a/lib/App/Cmd/Elective.pm
+++ b/lib/App/Cmd/Elective.pm
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+package App::Cmd::Elective;
+
+# ABSTRACT: load only ::Command::* from a whitelist
+
+use parent 'App::Cmd::Setup';
+
+require App::Cmd::Base::Elective;
+
+sub _app_base_class { 'App::Cmd::Base::Elective' }
+
+=head1 SYNOPSIS
+
+If you have an existing App which uses App::Cmd and you want to add whitelist only
+support, a simple change is required:
+
+    diff:
+
+    -use App::Cmd::Setup -app
+    +use App::Cmd::Elective -app
+
+    +sub app_commands {
+    +   qw( foo bar )
+    +}
+
+The function C<app_commands> returns a list of commandlets to load. ( In additional to any defaults provided by App::Cmd ).
+
+Note: Note these are B<NOT> nessecarily the same as the CLI command names, but these are the "providing module" names, which are expanded based upon the value of L<< C<plugin_search_path>|App::Cmd/plugin_search_path >>, and then the resulting command name is based on the individual modules values of L<< C<command_names>|App::Cmd::Command/command_names >>
+
+Otherwise, except for this minor difference, usage should be identical to that of App::Cmd's standard behaviour
+
+=cut
+
+1;


### PR DESCRIPTION
Here is what I have so far, it needs tests, and a more end-user targeted subclass that pulls commands to load from a config file is the next logical step.

However, this implementation is such that you _should_ be able to add this support simply by declaring a value of `sub app_commands` which loads the command list from a configuration file somewhere.

However, I do have `dzil` working with it, for instance

``` perl
#use App::Cmd::Setup 0.309 -app; # better compilation error detection
use App::Cmd::Elective -app;

sub app_commands { qw( xtest build perltidy ) }
```
