### PR TITLE
Don't die if classname to filename mapping fails

### DIFF
--- a/lib/App/Cmd/Command.pm
+++ b/lib/App/Cmd/Command.pm
@@ -205,7 +205,7 @@ sub abstract {
   # classname to filename
   (my $pm_file = $class) =~ s!::!/!g;
   $pm_file .= '.pm';
-  $pm_file = $INC{$pm_file};
+  $pm_file = $INC{$pm_file} or return "(unknown)";
 
   # if the pm file exists, open it and parse it
   open my $fh, "<", $pm_file or return "(unknown)";


### PR DESCRIPTION
This is a minor issue I stumbled upon: if a command was defined in a file that does not map to its package name (for instance a file that defines multiple command packages), the method died. With this fix, the abstract is just "(unknown)".
