### PR TITLE
correct prepare_default_command to _prepare_default_command and remove redundant definition in Subdispatch/DashedStyle

### DIFF
--- a/lib/App/Cmd/Subdispatch.pm
+++ b/lib/App/Cmd/Subdispatch.pm
@@ -50,7 +50,7 @@ sub prepare {
     if (@args) {
       return $self->_bad_command(undef, $opt, @sub_args);
     } else {
-      return $self->prepare_default_command($opt, @sub_args);
+      return $self->_prepare_default_command($opt, @sub_args);
     }
   }
 }

--- a/lib/App/Cmd/Subdispatch/DashedStyle.pm
+++ b/lib/App/Cmd/Subdispatch/DashedStyle.pm
@@ -32,15 +32,6 @@ sub get_command {
   }
 }
 
-=for Pod::Coverage prepare_default_command
-
-=cut
-
-sub prepare_default_command {
-  my ( $self, $opt, @args ) = @_;
-  $self->_prepare_command( "help" );
-}
-
 =method opt_spec
 
 A version of C<opt_spec> that calculates the getopt specification from the

--- a/t/subdispatch.t
+++ b/t/subdispatch.t
@@ -5,6 +5,8 @@ use warnings;
 
 use Test::More 'no_plan';
 
+use Test::Fatal;
+
 use lib 't/lib';
 
 BEGIN { use_ok('Test::MyCmd2') };
@@ -26,3 +28,7 @@ is_deeply( $cmd->app->global_options, { moose => 1 }, "subdispatcher global opti
 is_deeply( \@args, [] );
 
 is_deeply( $opt, { foo => => 1 } );
+
+is( exception { $app->prepare_command( 'foo' ) },
+    undef,
+    'run default subcommand for command' );


### PR DESCRIPTION
There appear to be typos in `Subdispatch.pm` and `Subdispatch/DashedStyle.pm`, wherein _prepare_default_command is mistakenly called as `prepare_default_command`. 

This results in a runtime failure when using `Subdispatch` (without `DashedStyle`), and invoking a command without a subcommand.  Normally this would result in the default subcommand being run, but instead one gets an error complaining that `prepare_default_command` is not defined.

Additionally, `Subdispatch/DashedStyle` implements a `prepare_default_command` subroutine, which (if my theory about the typo is correct) is redundant with the `_prepare_default_command` that is inherited from `Cmd.pm`.