### PR TITLE
Fix hard-coded path in t/basic.t

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use File::Spec;
 use Test::More tests => 15;
 use App::Cmd::Tester;
 
@@ -67,7 +68,10 @@ is_deeply(
 }
 
 my $return = test_app('Test::MyCmd', [ qw(--version) ]);
-my $version_expect = "basic.t (Test::MyCmd) version 0.123 (t/basic.t)\n";
+my $version_expect = sprintf(
+    "basic.t (Test::MyCmd) version 0.123 (%s)\n",
+    File::Spec->catfile(t => 'basic.t'),
+);
 is($return->stdout, $version_expect, "version plugin enabled");
 
 $return = test_app('Test::MyCmd', [ qw(commands) ]);


### PR DESCRIPTION
Hard coded path causes test failures with Windows style directory separators.
