### PR TITLE
Fix for commands/help relation (dzil-induced).

### DIFF
--- a/lib/App/Cmd/Command/commands.pm
+++ b/lib/App/Cmd/Command/commands.pm
@@ -29,8 +29,6 @@ sub execute {
 
   my $target = $opt->stderr ? *STDERR : *STDOUT;
 
-  print { $target } "Available commands:\n\n";
-
   my @primary_commands =
     grep { $_ ne 'version' }
     map { ($_->command_names)[0] }

--- a/lib/App/Cmd/Command/commands.pm
+++ b/lib/App/Cmd/Command/commands.pm
@@ -29,9 +29,6 @@ sub execute {
 
   my $target = $opt->stderr ? *STDERR : *STDOUT;
 
-  local $@;
-  eval { print { $target } $self->app->_usage_text . "\n" };
-
   print { $target } "Available commands:\n\n";
 
   my @primary_commands =

--- a/lib/App/Cmd/Command/help.pm
+++ b/lib/App/Cmd/Command/help.pm
@@ -86,21 +86,7 @@ sub execute {
   my ($self, $opts, $args) = @_;
 
   if (!@$args) {
-    my $usage = $self->app->usage->text;
-    my $command = $0;
-
-    # chars normally used to describe options
-    my $opt_descriptor_chars = qr/[\[\]<>\(\)]/;
-
-    if ($usage =~ /^(.+?) \s* (?: $opt_descriptor_chars | $ )/x) {
-      # try to match subdispatchers too
-      $command = $1;
-    }
-
-    # evil hack ;-)
-    bless
-      $self->app->{usage} = sub { return "$command help <command>\n" }
-      => "Getopt::Long::Descriptive::Usage";
+    print $self->app->usage->text . "\n";
 
     $self->app->execute_command( $self->app->_prepare_command("commands") );
   } else {

--- a/lib/App/Cmd/Command/help.pm
+++ b/lib/App/Cmd/Command/help.pm
@@ -88,6 +88,8 @@ sub execute {
   if (!@$args) {
     print $self->app->usage->text . "\n";
 
+    print "Available commands:\n\n";
+
     $self->app->execute_command( $self->app->_prepare_command("commands") );
   } else {
     my ($cmd, $opt, $args) = $self->app->prepare_command(@$args);


### PR DESCRIPTION
The issues were filed against `DZ`: rjbs/Dist-Zilla#177 & rjbs/Dist-Zilla#340. Two changes here:
* the hack in *help.pm* (blessing a subref into `GLD`) was not working -- you can easily see this by peeking into `$@` in *commands.pm*; now it does not omit basic usage pattern on `dzil help`
* as noted in rjbs/Dist-Zilla#340 it seems reasonable to make `commands` less verbose -- hence the subhead was moved to *help.pm*.

This PR is part of my [advent quest](https://questhub.io/realm/perl/quest/547b4202070ccf750d00010e).

Cheers,
Sergey.