### PR TITLE
Subdispatch: Can't locate object method "prepare_default_command"

### DIFF
--- a/lib/App/Cmd/Subdispatch.pm
+++ b/lib/App/Cmd/Subdispatch.pm
@@ -55,6 +55,11 @@ sub prepare {
   }
 }
 
+sub prepare_default_command {
+  my ( $self, $opt, @args ) = @_;
+  $self->_prepare_command( "help" );
+}
+
 sub _plugin_prepare {
   my ($self, $plugin, @args) = @_;
   return $plugin->prepare($self->choose_parent_app($self->app, $plugin), @args);


### PR DESCRIPTION
I have a subdispatch command setup, e.g.

MyApp::Command::foo
MyApp::Command::foo::bar

When I was running the 'foo' command alone, e.g.

    bin/myapp foo

I was getting this error:

    Can't locate object method "prepare_default_command" via package "MyApp::Command::foo" at /home/vagrant/CE/bin/../extlib/lib/perl5/App/Cmd/Subdispatch.pm line 53.

Looks like App::Cmd::Subdispatch::DashedStyle handles this correctly, so I just ported the prepare_default_command method from that module into App::Cmd::Subdispatch, now I'm correctly getting a help screen.
