### PR TITLE
Add show_version_cmd option [#45]

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for App-Cmd
 
 {{$NEXT}}
 
+        - add 'show_version_cmd' option to enable display of 'version'
+          command in command list. (John Anderson)
+
 0.327     2015-02-23 20:05:00-05:00 America/New_York
         - fix behavior of default command under subdispatch (thanks, Stephen
           Caldwell and Diab Jerius!)

--- a/lib/App/Cmd.pm
+++ b/lib/App/Cmd.pm
@@ -131,6 +131,9 @@ Valid arguments are:
 
   no_version_plugin  - if true, the version plugin is not added
 
+  show_version_cmd -   if true, the version command will be shown in the
+                       command list
+
   plugin_search_path - The path to search for commands in. Defaults to
                        results of plugin_search_path method
 
@@ -145,8 +148,9 @@ the default help plugin, you should provide your own or override the
 C<default_command> method.
 
 If C<no_version_plugin> is not given, L<App::Cmd::Command::version> will be
-required to show the application's version with command C<--version>. The
-version command is not included in the command list.
+required to show the application's version with command C<--version>. By
+default, the version command is not included in the command list. Pass
+C<show_version_cmd> to include the version command in the list.
 
 =cut
 
@@ -157,9 +161,10 @@ sub new {
   my $base = File::Basename::basename $arg0;
 
   my $self = {
-    command   => $class->_command($arg),
-    arg0      => $base,
-    full_arg0 => $arg0,
+    command      => $class->_command($arg),
+    arg0         => $base,
+    full_arg0    => $arg0,
+    show_version => $arg->{show_version_cmd} || 0,
   };
 
   bless $self => $class;

--- a/lib/App/Cmd/Command/commands.pm
+++ b/lib/App/Cmd/Command/commands.pm
@@ -30,7 +30,7 @@ sub execute {
   my $target = $opt->stderr ? *STDERR : *STDOUT;
 
   my @primary_commands =
-    grep { $_ ne 'version' }
+    grep { $_ ne 'version' or $self->app->{show_version} }
     map { ($_->command_names)[0] }
     $self->app->command_plugins;
 

--- a/t/version.t
+++ b/t/version.t
@@ -1,0 +1,28 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use App::Cmd::Tester;
+
+use lib 't/lib';
+
+use Test::MyCmd;
+
+{
+  my $app = Test::MyCmd->new({ show_version_cmd => 1 });
+  my $ret = App::Cmd::Tester->_run_with_capture( $app , [ 'commands' ]);
+
+  like( $ret->{output} , qr/version/ , 'see version in output');
+  is( $ret->{error} , undef , 'no errors' );
+}
+{
+  my $app = Test::MyCmd->new({ show_version_cmd => 0 });
+  my $ret = App::Cmd::Tester->_run_with_capture( $app , [ 'commands' ]);
+
+  unlike( $ret->{output} , qr/version/ , 'do not see version in output');
+  is( $ret->{error} , undef , 'no errors' );
+}
+
+done_testing;


### PR DESCRIPTION
If there's a better place to stick that option than inside the App::Cmd object, let me know -- none of the existing constructor options need to be available inside a command in quite the same way this one does. I took the path of least resistance, but I'm not sure that it's the path of best design...
