### PR TITLE
improve version command abstract

### DIFF
--- a/lib/App/Cmd/Command/version.pm
+++ b/lib/App/Cmd/Command/version.pm
@@ -6,7 +6,7 @@ package App::Cmd::Command::version;
 use App::Cmd::Command;
 BEGIN { our @ISA = 'App::Cmd::Command'; }
 
-# ABSTRACT: display an app's version
+# ABSTRACT: display the app's version and full name
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
There is always one particular app (with multiple commands), so abstracts should better be this:

```
     help: display a command's help screen
  version: display the app's version and full name
```