### PR TITLE
Support group headers in commands command

### DIFF
--- a/lib/App/Cmd.pm
+++ b/lib/App/Cmd.pm
@@ -543,6 +543,20 @@ sub command_names {
   keys %{ $self->_command };
 }
 
+=method command_groups
+
+  my @groups = $cmd->commands_groups;
+
+This method can be implemented to return a grouped list of command names with
+optional headers. Each group is given as arrayref and each header as string.
+If an empty list is returned, the commands plugin will show two groups without
+headers: the first group is for the "help" and "commands" commands, and all
+other commands are in the second group.
+
+=cut
+
+sub command_groups { }
+
 =method command_plugins
 
   my @plugins = $cmd->command_plugins;

--- a/lib/App/Cmd/Command/commands.pm
+++ b/lib/App/Cmd/Command/commands.pm
@@ -28,13 +28,18 @@ sub execute {
   my ($self, $opt, $args) = @_;
 
   my $target = $opt->stderr ? *STDERR : *STDOUT;
+ 
+  my @cmd_groups = $self->app->command_groups;
+  my @primary_commands = map { @$_ if ref $_ } @cmd_groups;
 
-  my @primary_commands =
-    grep { $_ ne 'version' }
-    map { ($_->command_names)[0] }
-    $self->app->command_plugins;
+  if (!@cmd_groups) {
+    @primary_commands =
+      grep { $_ ne 'version' }
+      map { ($_->command_names)[0] }
+      $self->app->command_plugins;
 
-  my @cmd_groups = $self->sort_commands(@primary_commands);
+    @cmd_groups = $self->sort_commands(@primary_commands);
+  }
 
   my $fmt_width = 0;
   for (@primary_commands) { $fmt_width = length if length > $fmt_width }
@@ -62,6 +67,9 @@ arrayrefs, and optional group header strings.
 
 By default, the first group is for the "help" and "commands" commands, and all
 other commands are in the second group.
+
+This method can be overriden by implementing the C<commands_groups> method in
+your application base clase.
 
 =cut
 

--- a/lib/App/Cmd/Command/commands.pm
+++ b/lib/App/Cmd/Command/commands.pm
@@ -41,6 +41,10 @@ sub execute {
   $fmt_width += 2; # pretty
 
   foreach my $cmd_set (@cmd_groups) {
+    if (!ref $cmd_set) {
+      print { $target } "$cmd_set:\n";
+      next;
+    }
     for my $command (@$cmd_set) {
       my $abstract = $self->app->plugin_for($command)->abstract;
       printf { $target } "%${fmt_width}s: %s\n", $command, $abstract;
@@ -53,8 +57,8 @@ sub execute {
 
   my @sorted = $cmd->sort_commands(@unsorted);
 
-This method orders the list of commands into sets which it returns as a list of
-arrayrefs.
+This method orders the list of commands into groups which it returns as a list of
+arrayrefs, and optional group header strings.
 
 By default, the first group is for the "help" and "commands" commands, and all
 other commands are in the second group.


### PR DESCRIPTION
To give an example I use this commands group in my application:

```perl
sub command_groups {
    return (
        "PAIA auth commands" => [qw(login logout change)],
        "PAIA core commands" => [qw(patron items request renew cancel fees)],
        "client commands"    => [qw(config session help commands version)]
    );
}
```

This extension also allows to include/exclude the `version` command (issue #45)