### PR TITLE
App::Cmd::Tester's exit replacement

### DIFF
--- a/lib/App/Cmd/Tester.pm
+++ b/lib/App/Cmd/Tester.pm
@@ -65,8 +65,9 @@ use Sub::Exporter -setup => {
 our $TEST_IN_PROGRESS;
 BEGIN {
   *CORE::GLOBAL::exit = sub {
-    return CORE::exit(@_) unless $TEST_IN_PROGRESS;
-    App::Cmd::Tester::Exited->throw($_[0]);
+    my ($rc) = @_;
+    return CORE::exit($rc) unless $TEST_IN_PROGRESS;
+    App::Cmd::Tester::Exited->throw($rc);
   };
 }
 

--- a/t/tester-exit.helper.pl
+++ b/t/tester-exit.helper.pl
@@ -1,0 +1,10 @@
+#!perl
+use strict;
+use warnings;
+
+use App::Cmd::Tester;
+
+my ($exit_with) = @ARGV;
+print "$INC{'App/Cmd/Tester.pm'}\n";
+
+exit $exit_with; # nb. the App::Cmd::Tester one

--- a/t/tester-exit.t
+++ b/t/tester-exit.t
@@ -1,0 +1,25 @@
+#!perl
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+use Capture::Tiny 'capture';
+
+require App::Cmd::Tester; # not used, but check which!
+
+my $helper_fn = $0;
+$helper_fn =~ s{\.t$}{.helper.pl} or die "Can't make helper from $0";
+
+for my $exit_with (0, 5) {
+  my ($stdout, $stderr, $got_exit) = capture {
+    system($^X, $helper_fn, $exit_with);
+  };
+
+  chomp $stdout;
+  is($INC{'App/Cmd/Tester.pm'}, $stdout, "App::Cmd::Tester source path")
+    unless $exit_with; # just once
+
+  is($exit_with,
+     $got_exit / 256, # yes it could be fractional, and that would be fail
+     "exit code as expected");
+}


### PR DESCRIPTION
Old one was broken.  Test & patch included.

Without this, the following (example, untested) test code will fail.

```perl
use App::Cmd::Tester;
use Test::More tests => 1;
ok(1, "no worries");
exit 0; # actually ends up doing exit(1)
```