### PR TITLE
Remove duplicate help entries to avoid getopt warning

### DIFF
--- a/lib/App/Cmd.pm
+++ b/lib/App/Cmd.pm
@@ -11,6 +11,7 @@ BEGIN { our @ISA = 'App::Cmd::ArgProcessor' };
 use File::Basename ();
 use Module::Pluggable::Object ();
 use Class::Load ();
+use List::MoreUtils qw(uniq);
 
 use Sub::Exporter -setup => {
   collectors => {
@@ -691,8 +692,10 @@ sub global_opt_spec {
   my ($self) = @_;
 
   my $cmd = $self->{command};
-  my @help = reverse sort map { s/^--?//; $_ }
-             grep { $cmd->{$_} eq 'App::Cmd::Command::help' } keys %$cmd;
+  # Use two sets of parens to ensure the result of uniq goes to sort
+  # instead of sort using uniq as the operator.
+  my @help = reverse sort(uniq(map { s/^--?//; $_ }
+             grep { $cmd->{$_} eq 'App::Cmd::Command::help' } keys %$cmd));
 
   return (@help ? [ join('|', @help) => "show help" ] : ());
 }


### PR DESCRIPTION
I noticed my program start producing a warning coming from `Getopt::Long`:

> Duplicate specification "help|help|h|?" for option "help"

With `$^W` on you can see it with any program:

```
💥  perl -S dzil authordeps
Dist::Zilla::PluginBundle::Author::RWSTAUNER
Software::License::Perl_5
💥  perl -w -S dzil authordeps
Duplicate specification "help|help|h|?" for option "help"
Dist::Zilla::PluginBundle::Author::RWSTAUNER
Software::License::Perl_5
```

You may want an alternative solution since the patch got a bit gross (or maybe you don't want `List::MoreUtils`).
I didn't dig into writing a test for it, but I wanted to present the issue before I forgot.