### PR TITLE
Do not mention App::Cmd::Plugin as the place to find plugin docs

### DIFF
--- a/lib/App/Cmd/Setup.pm
+++ b/lib/App/Cmd/Setup.pm
@@ -33,7 +33,7 @@ plugins, as in:
   package MyApp;
   use App::Cmd::Setup -app => { plugins => [ 'Prompt' ] };
 
-Plugins are described in L<App::Cmd::Tutorial> and L<App::Cmd::Plugin>.
+Plugins are described in L<App::Cmd::Tutorial>.
 
 = when writing abstract base classes for commands
 


### PR DESCRIPTION
This fixes GH #38, which shows a confusion about a class providing documentation but it has none.