### PR TITLE
add manpage plugin to run pod2usage on command or subcommands

### DIFF
--- a/lib/App/Cmd.pm
+++ b/lib/App/Cmd.pm
@@ -133,6 +133,8 @@ Valid arguments are:
 
   no_help_plugin     - if true, the help plugin is not added
 
+  no_manpage_plugin  - if true, the manpage plugin is not added
+
   no_version_plugin  - if true, the version plugin is not added
 
   show_version_cmd -   if true, the version command will be shown in the
@@ -150,6 +152,11 @@ and it will be registered to handle all of its command names not handled by
 other plugins. B<Note:> "help" is the default command, so if you do not load
 the default help plugin, you should provide your own or override the
 C<default_command> method.
+
+if C<no_manpage_plugin> is not given, L<App::Cmd::Command::manpage>
+will be required.  It provides the C<manpage> (or C<--manpage>) command which
+will format and display the POD in the script (if no arguments are given)
+or in the module of the specified command (if a command name is given).
 
 If C<no_version_plugin> is not given, L<App::Cmd::Command::version> will be
 required to show the application's version with command C<--version>. By
@@ -216,7 +223,7 @@ sub _command {
     }
   }
 
-  $self->_load_default_plugin($_, $arg, \%plugin) for qw(commands help version);
+  $self->_load_default_plugin($_, $arg, \%plugin) for qw(commands help manpage version);
 
   if ($self->allow_any_unambiguous_abbrev) {
     # add abbreviations to list of authorized commands

--- a/lib/App/Cmd/Command/manpage.pm
+++ b/lib/App/Cmd/Command/manpage.pm
@@ -29,9 +29,9 @@ sub opt_spec { [ 'no-pager' => "don't page output", { default => 0 } ] }
 
 sub command_names { qw/manpage man --man --manpage/ }
 
-sub abstract { "display a command's manual page" }
+sub abstract { "display the application's manual page or that of a particular command" }
 
-sub description { "display a command's manual page" }
+sub description { "display the application's manual page or that of a particular command" }
 
 sub execute {
     my ( $self, $opts, $args ) = @_;

--- a/lib/App/Cmd/Command/manpage.pm
+++ b/lib/App/Cmd/Command/manpage.pm
@@ -1,0 +1,75 @@
+package App::Cmd::Command::manpage;
+
+use strict;
+use warnings;
+
+use App::Cmd -command;
+use Pod::Find qw[ pod_where ];
+use Pod::Usage qw[ pod2usage ];
+use File::Spec::Functions qw[ catdir ];
+
+# ABSTRACT: display a command's manual page
+
+=head1 DESCRIPTION
+
+This command will display a manual page for a command based upon POD
+embedded in the command's source.  If no POD is available, it will
+fail with an error.
+
+=head1 USAGE
+
+The manual text is generated using L<Pod::Usage/pod2usage> with
+a verbosity level of C<2> and an exit value of C<0>.
+
+=cut
+
+sub usage_desc { '%c manpage %o [subcommand]' }
+
+sub opt_spec { [ 'no-pager' => "don't page output", { default => 0 } ] }
+
+sub command_names { qw/manpage man --man --manpage/ }
+
+sub abstract { "display a command's manual page" }
+
+sub description { "display a command's manual page" }
+
+sub execute {
+    my ( $self, $opts, $args ) = @_;
+
+    my @usage_args;
+
+    if ( !@$args ) {
+        require FindBin;
+        push @usage_args, -input => catdir( $FindBin::RealBin, $FindBin::RealScript );
+    }
+    else {
+
+        my $plugin;
+        unless ( $plugin = $self->app->plugin_for( $args->[0] ) ) {
+            $self->app->execute_command(
+                $self->app->_bad_command( $args->[0], $opts, $args ) );
+            exit 1;
+        }
+
+        my $file;
+        unless ( $file = pod_where( { -inc => 1 }, $plugin ) ) {
+            print STDERR "No documentation for command '$args->[0]'\n";
+            exit 1;
+        }
+
+        push @usage_args, -input => $file;
+    }
+
+    pod2usage(
+        -exitval   => 0,
+        -verbose   => 2,
+        -noperldoc => $opts->no_pager,
+        @usage_args
+    );
+
+}
+
+1;
+
+
+

--- a/t/abbrev.t
+++ b/t/abbrev.t
@@ -13,6 +13,7 @@ use Test::MyCmdAbbrev;
 my $app = Test::MyCmdAbbrev->new( {
     no_commands_plugin => 1,
     no_help_plugin     => 1,
+    no_manpage_plugin     => 1,
     no_version_plugin  => 1,
 } );
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -16,7 +16,7 @@ isa_ok($app, 'Test::MyCmd');
 
 is_deeply(
   [ sort $app->command_names ],
-  [ sort qw(help --help -h --version -? commands exit frob frobulate hello justusage stock version) ],
+  [ sort qw(help --help -h --man --manpage --version -? commands exit frob frobulate hello justusage man manpage stock version) ],
   "got correct list of registered command names",
 );
 
@@ -25,6 +25,7 @@ is_deeply(
   [ qw(
     App::Cmd::Command::commands
     App::Cmd::Command::help
+    App::Cmd::Command::manpage
     App::Cmd::Command::version
     Test::MyCmd::Command::exit
     Test::MyCmd::Command::frobulate

--- a/t/callback.t
+++ b/t/callback.t
@@ -17,7 +17,7 @@ my $app = $CLASS->new;
 
 is_deeply(
   [ sort $app->command_names ],
-  [ sort qw(help --help -h --version -? commands lol version) ],
+  [ sort qw(help --help -h --man --manpage --version -? commands lol man manpage version) ],
   "got correct list of registered command names",
 );
 

--- a/t/manpage.t
+++ b/t/manpage.t
@@ -1,0 +1,66 @@
+#!perl
+use strict;
+use warnings;
+
+use Test::More;
+use App::Cmd::Tester;
+
+use lib 't/lib';
+
+use Test::MyCmd;
+
+subtest 'subcommand' => sub {
+    my $return = test_app( 'Test::MyCmd', [qw(manpage --no-pager exit)] );
+
+    my $stdout = $return->stdout;
+
+    like( $stdout, qr/\S/, "manual page text was output", )
+      or note $return->error;
+
+    like(
+        $stdout,
+        qr/NAME\s+Test::MyCmd::Command::exit/,
+        "NAME section was output",
+    ) or note $return->error;
+
+    like(
+        $stdout,
+        qr/DESCRIPTION\s+This package exists/,
+        "DESCRIPTION section was output",
+    ) or note $return->error;
+
+};
+
+subtest 'command' => sub {
+    my $return = test_app( 'Test::MyCmd', [qw(manpage --no-pager)] );
+
+    my $stdout = $return->stdout;
+
+    like( $stdout, qr/\S/, "manual page text was output", )
+      or note $return->error;
+
+    like(
+        $stdout,
+        qr/NAME\s+manpage.t/,
+        "NAME section was output",
+    ) or note $return->error;
+
+    like(
+        $stdout,
+        qr/DESCRIPTION\s+manpage test description/,
+        "DESCRIPTION section was output",
+    ) or note $return->error;
+
+};
+
+done_testing();
+
+__END__
+
+=head1 NAME
+
+manpage.t
+
+=head1 DESCRIPTION
+
+manpage test description

--- a/t/setup-inner.t
+++ b/t/setup-inner.t
@@ -16,7 +16,7 @@ my $app = $CLASS->new;
 
 is_deeply(
   [ sort $app->command_names ],
-  [ sort qw(help --help -h --version -? commands poot version) ],
+  [ sort qw(help --help -h --man --manpage --version -? commands man manpage poot version) ],
   "got correct list of registered command names",
 );
 
@@ -25,6 +25,7 @@ is_deeply(
   [ qw(
     App::Cmd::Command::commands
     App::Cmd::Command::help
+    App::Cmd::Command::manpage
     App::Cmd::Command::version
     Test::WSOF::Command::poot
   ) ],

--- a/t/setup-nocmd.t
+++ b/t/setup-nocmd.t
@@ -25,7 +25,7 @@ my $app = $CLASS->new;
 
 is_deeply(
   [ sort $app->command_names ],
-  [ sort qw(help --help -h --version -? commands blort version) ],
+  [ sort qw(help --help -h --man --manpage --version -? commands blort man manpage version) ],
   "got correct list of registered command names",
 );
 
@@ -34,6 +34,7 @@ is_deeply(
   [ qw(
     App::Cmd::Command::commands
     App::Cmd::Command::help
+    App::Cmd::Command::manpage
     App::Cmd::Command::version
     Test::WSNCC::Command::blort
   ) ],

--- a/t/setup.t
+++ b/t/setup.t
@@ -16,7 +16,7 @@ my $app = $CLASS->new;
 
 is_deeply(
   [ sort $app->command_names ],
-  [ sort qw(help --help -h --version -? commands alfie bertie version) ],
+  [ sort qw(help --help -h --man --manpage --version -? commands alfie bertie man manpage version) ],
   "got correct list of registered command names",
 );
 
@@ -25,6 +25,7 @@ is_deeply(
   [ qw(
     App::Cmd::Command::commands
     App::Cmd::Command::help
+    App::Cmd::Command::manpage
     App::Cmd::Command::version
     Test::WithSetup::Command::alfie
     Test::WithSetup::Command::bertie


### PR DESCRIPTION
This adds a `manpage` plugin, which uses `Pod::Usage::pod2usage` to format and output documentation gleaned from either the script file (if no command is given) or the specified command.
